### PR TITLE
[feat] add rowspan property

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,3 +562,11 @@ labs:
 **Change the way assignments are rendered?**
 - All the code for rendering a single assignment is in `_includes/homework.html`. For simplicity, the other assignment files (`_includes/project.html` and `_includes/lab.html`) are identical. You should only need to edit these files.
 - These files are already made to be fairly extensible (e.g. `parts` for rendering any list of links, and `extra` for any arbitrary Markdown), so you may be able to achieve the desired behavior without changing these HTML files.
+
+
+**Render multiple lectures/discussions/assignments on a single day?**
+- If you only need this once (e.g. there's only one day all semester with two lectures), the easiest solution is probably to use `extra_days` in `syllabus.yml`. The day will render twice in the "Date" column. This is much easier than the alternative below.
+- If you need this repeatedly (e.g. there's two lectures on every day), then change `day_rowspan` in `syllabus.yml`. Note that all the other rowspans must now be calculated relative to your updated `day_rowspan`.
+- Example of `day_rowspan` usage: Suppose you have two lectures on each of MWF, and two discussions per week. Then you want `day_rowspan: 2` and `default_lecture_rowspan: 1` so that two lectures get rendered per day. Since a week now spans 6 rows, you want `discussion_default_rowspan: 3` so that two discussions are rendered per week.
+- More generally, if you change `day_rowspan` to `n`, then you want to multiply every other `default_rowspan` by `n` to get the original table unchanged. But now you can get multiple rows per day by setting some rowspans to be less than `n`.
+- The `day_rowspan` feature can be confusing so we don't recommend using it unless you know what you're doing.

--- a/_data/discussions.yml
+++ b/_data/discussions.yml
@@ -119,7 +119,7 @@ discussions:
     examprep_slides: ""
     extra: |
       [61C Review Video](https://www.youtube.com/watch?v=WVhKJqCqwyE)
-    rowspan: 1
+    rowspan: 2
   - title: "Security Principles and x86"
     show_worksheet: true
     show_sols: true
@@ -143,4 +143,4 @@ discussions:
     examprep_video: "https://www.youtube.com/playlist?list=PLfBkt1-_BHX8JTBNVlgRogrYsfHG7k6ql"
     regular_slides: ""
     examprep_slides: ""
-    rowspan: "3" # because this week has an extra row for the midterm
+    rowspan: "6" # because this week has an extra row for the midterm

--- a/_data/discussions.yml
+++ b/_data/discussions.yml
@@ -119,7 +119,7 @@ discussions:
     examprep_slides: ""
     extra: |
       [61C Review Video](https://www.youtube.com/watch?v=WVhKJqCqwyE)
-    rowspan: 2
+    rowspan: "1"
   - title: "Security Principles and x86"
     show_worksheet: true
     show_sols: true
@@ -143,4 +143,4 @@ discussions:
     examprep_video: "https://www.youtube.com/playlist?list=PLfBkt1-_BHX8JTBNVlgRogrYsfHG7k6ql"
     regular_slides: ""
     examprep_slides: ""
-    rowspan: "6" # because this week has an extra row for the midterm
+    rowspan: "3" # because this week has an extra row for the midterm

--- a/_data/homeworks.yml
+++ b/_data/homeworks.yml
@@ -80,7 +80,7 @@ homeworks:
         link: "https://www.gradescope.com/courses/942380/assignments/5689760"
       - name: "Part B"
         link: "https://www.gradescope.com/courses/942380/assignments/5689747"
-    rowspan: "1"
+    rowspan: "2"
   - title: "" # blank for auto-numbering as "HW2"
     link: ""
     show_links: true
@@ -101,5 +101,5 @@ homeworks:
         link: "https://www.gradescope.com/courses/942380/assignments/5788266"
       - name: "Part B"
         link: "https://www.gradescope.com/courses/942380/assignments/5788277"
-    rowspan: "3" # because this week has an extra row for the midterm
+    rowspan: "6" # because this week has an extra row for the midterm
   - nonumber: true # blank box in Week 5 (otherwise you get auto-numbered "HW4")

--- a/_data/homeworks.yml
+++ b/_data/homeworks.yml
@@ -80,7 +80,7 @@ homeworks:
         link: "https://www.gradescope.com/courses/942380/assignments/5689760"
       - name: "Part B"
         link: "https://www.gradescope.com/courses/942380/assignments/5689747"
-    rowspan: "2"
+    rowspan: "1"
   - title: "" # blank for auto-numbering as "HW2"
     link: ""
     show_links: true
@@ -101,5 +101,5 @@ homeworks:
         link: "https://www.gradescope.com/courses/942380/assignments/5788266"
       - name: "Part B"
         link: "https://www.gradescope.com/courses/942380/assignments/5788277"
-    rowspan: "6" # because this week has an extra row for the midterm
+    rowspan: "3" # because this week has an extra row for the midterm
   - nonumber: true # blank box in Week 5 (otherwise you get auto-numbered "HW4")

--- a/_data/labs.yml
+++ b/_data/labs.yml
@@ -79,7 +79,6 @@ labs:
       - name: "Part B"
         link: "/proj1/part-b"
     extra: "[Special PDF](https://www.google.com)"
-    rowspan: 3
     classes:
       - proj1 # adds the purple background
   - nonumber: true

--- a/_data/lectures.yml
+++ b/_data/lectures.yml
@@ -76,6 +76,7 @@ lectures:
     readings:
       - name: "Ch. 1"
         link: "https://textbook.cs161.org/principles/principles.html"
+  - title: "Intro Lecture pt2"
   - title: "x86 Assembly and Call Stack"
     slides: "" # example of lecture slides automatically linking to a PDF file instead of Google Slides
     recording: "https://www.youtube.com/playlist?list=PLfBkt1-_BHX_R0dlFGLnAxOEJtWXahfdN"
@@ -84,13 +85,15 @@ lectures:
         link: "https://textbook.cs161.org/memory-safety/x86.html"
       - name: "x86/GDB Cheat Sheet"
         link: "https://assets.cs161.org/proj1/cheatsheet.pdf"
-    rowspan: "2"
+    #rowspan: "4"
+  - title: "x86 Lecture pt2"
   - title: "Memory Safety Vulnerabilities"
     slides: "https://docs.google.com/presentation/d/1M_oyCC1OE5oZPh7Qiwp8X2IIlWa6AAvel3ST0ndFgts"
     recording: "https://www.youtube.com/playlist?list=PLfBkt1-_BHX9NcOVQ3z0tKo7_5uJpUajl"
     readings:
       - name: "Ch. 3"
         link: "https://textbook.cs161.org/memory-safety/vulnerabilities.html"
+  - title: "Memory Safety Vulnerabilities Lecture pt2"
   - title: "Holiday (No Lecture)"
     nonumber: true # skips assigning a number to this box
   - title: "Memory Safety Vulnerabilities 2"

--- a/_data/lectures.yml
+++ b/_data/lectures.yml
@@ -85,14 +85,6 @@ lectures:
         link: "https://textbook.cs161.org/memory-safety/x86.html"
       - name: "x86/GDB Cheat Sheet"
         link: "https://assets.cs161.org/proj1/cheatsheet.pdf"
-    #rowspan: "4"
-  - title: "x86 Lecture pt2"
-  - title: "Memory Safety Vulnerabilities"
-    slides: "https://docs.google.com/presentation/d/1M_oyCC1OE5oZPh7Qiwp8X2IIlWa6AAvel3ST0ndFgts"
-    recording: "https://www.youtube.com/playlist?list=PLfBkt1-_BHX9NcOVQ3z0tKo7_5uJpUajl"
-    readings:
-      - name: "Ch. 3"
-        link: "https://textbook.cs161.org/memory-safety/vulnerabilities.html"
   - title: "Memory Safety Vulnerabilities Lecture pt2"
   - title: "Holiday (No Lecture)"
     nonumber: true # skips assigning a number to this box

--- a/_data/syllabus.yml
+++ b/_data/syllabus.yml
@@ -45,6 +45,12 @@ starting_project_number: '1'
 # starting at any other week number, so pick '0' or '1' here.
 starting_week_number: '1'
 
+# Change this if you want multiple lecture/discussion/etc boxes on the same day.
+# All the other rowspans must be relative to the day rowspan, e.g. a homework 
+# spanning 3 days on the calendar would need rowspan 3 * day_rowspan.
+# This should be 1 unless you know what you're doing.
+day_rowspan: '2'
+
 # How many rows should each assignment take up by default?
 # We have one lecture per row. Highly unlikely you'll need to change this.
 default_lecture_rowspan: '1'
@@ -61,11 +67,6 @@ default_lab_rowspan: '8'
 # Project rowspans are too variable, so we just set the default to 1 and
 # never use the default (always manually specifying the rowspan).
 default_project_rowspan: '1'
-# Change this if you want multiple lecture/discussion/etc boxes on the same day.
-# If this is changed, all the other rowspans must be relative to the day rowspan,
-# e.g. a homework spanning 3 days on the calendar would need rowspan 3 * default_day_rowspan.
-# This should be 1 unless you know what you're doing.
-default_day_rowspan: '2'
 
 # Do you want cells to automatically alternate colors each week?
 # Usually the answer is yes/true if the cell appears with a regular fixed

--- a/_data/syllabus.yml
+++ b/_data/syllabus.yml
@@ -49,21 +49,21 @@ starting_week_number: '1'
 # All the other rowspans must be relative to the day rowspan, e.g. a homework 
 # spanning 3 days on the calendar would need rowspan 3 * day_rowspan.
 # This should be 1 unless you know what you're doing.
-day_rowspan: '2'
+day_rowspan: '1'
 
 # How many rows should each assignment take up by default?
 # We have one lecture per row. Highly unlikely you'll need to change this.
 default_lecture_rowspan: '1'
-default_readings_rowspan: '2'
+default_readings_rowspan: '1'
 # This probably corresponds to how many rows you have per week, assuming
 # you hold discussion once per week. For example, if you have Tu/Th classes
 # (two rows per week), then your discussion boxes are probably going to
 # take up two rows most of the time, so you'd set default_discussion_rowspan='2'.
 # If you have M/W/F classes, though, this might be '3' instead.
-default_discussion_rowspan: '4'
+default_discussion_rowspan: '2'
 # Similar reasoning to discussion, assuming your homeworks/labs are weekly.
-default_homework_rowspan: '4'
-default_lab_rowspan: '8'
+default_homework_rowspan: '2'
+default_lab_rowspan: '4'
 # Project rowspans are too variable, so we just set the default to 1 and
 # never use the default (always manually specifying the rowspan).
 default_project_rowspan: '1'

--- a/_data/syllabus.yml
+++ b/_data/syllabus.yml
@@ -48,19 +48,24 @@ starting_week_number: '1'
 # How many rows should each assignment take up by default?
 # We have one lecture per row. Highly unlikely you'll need to change this.
 default_lecture_rowspan: '1'
-default_readings_rowspan: '1'
+default_readings_rowspan: '2'
 # This probably corresponds to how many rows you have per week, assuming
 # you hold discussion once per week. For example, if you have Tu/Th classes
 # (two rows per week), then your discussion boxes are probably going to
 # take up two rows most of the time, so you'd set default_discussion_rowspan='2'.
 # If you have M/W/F classes, though, this might be '3' instead.
-default_discussion_rowspan: '2'
+default_discussion_rowspan: '4'
 # Similar reasoning to discussion, assuming your homeworks/labs are weekly.
-default_homework_rowspan: '2'
-default_lab_rowspan: '4'
+default_homework_rowspan: '4'
+default_lab_rowspan: '8'
 # Project rowspans are too variable, so we just set the default to 1 and
 # never use the default (always manually specifying the rowspan).
 default_project_rowspan: '1'
+# Change this if you want multiple lecture/discussion/etc boxes on the same day.
+# If this is changed, all the other rowspans must be relative to the day rowspan,
+# e.g. a homework spanning 3 days on the calendar would need rowspan 3 * default_day_rowspan.
+# This should be 1 unless you know what you're doing.
+default_day_rowspan: '2'
 
 # Do you want cells to automatically alternate colors each week?
 # Usually the answer is yes/true if the cell appears with a regular fixed

--- a/_includes/syllabus.html
+++ b/_includes/syllabus.html
@@ -42,7 +42,7 @@
 {%- assign sorted_dates = valid_dates | sort | group_by_exp: 'it', "it | date: '%U'" -%}
 
 <div>
-  <table>
+  <table class="spanned-table">
     {%- comment -%}
       - Table header.
       - Use syllabus.yml to change table widths.
@@ -50,7 +50,7 @@
         We have two additional columns pre-built; just uncomment them to use.
     {%- endcomment -%}
     <thead>
-      <tr>
+      <tr class="starting-row">
         <th style="width:{{ site.data.syllabus.week_width }}">Wk.</th>
         <th style="width:{{ site.data.syllabus.date_width }}">Date</th>
         <th style="width:{{ site.data.syllabus.lecture_width }}">Lecture</th>
@@ -122,8 +122,10 @@
       {%- comment -%}
         - These are the default rowspans we assume if you don't provide one in
         the yml file.
+        - All rowspans are relative to the day_rowspan, which is defined in syllabus.yml.
         - See syllabus.yml for more information on what these are, and to modify them.
       {%- endcomment -%}
+      {%- assign day_rowspan = site.data.syllabus.day_rowspan -%}
       {%- assign default_lecture_rowspan = site.data.syllabus.default_lecture_rowspan -%}
       {%- assign default_readings_rowspan = site.data.syllabus.default_readings_rowspan -%}
       {%- assign default_discussion_rowspan = site.data.syllabus.default_discussion_rowspan -%}
@@ -167,234 +169,249 @@
           - In a given week, iterate through all the days in that week.
         {%- endcomment -%}
         {%- for day in week.items -%}
-          {%- assign first_day = forloop.first -%}
-          {%- assign start = 1 -%}
-          {%- for i in (start...site.data.syllabus.default_day_rowspan) -%}
-          <tr>
-            {%- comment -%}
-              - Render the week number column.
-              - We use forloop.first to render the week number only once per week.
-              - We use the "size" field of the week hash to see how many days we're
-              going to display in the week, which tells us how many rows the week
-              number needs to span.
-              - We use the "name" field of the week hash to give us a unique week
-              number (between 1 and 52), which gives each week number box a unique
-              id, and thus allows us to implement the "jump to current week"
-              functionality.
-              - Additional text (e.g. link to weekly survey) can be placed underneath
-                the week number by using week_extra.yml.
-              - week-cell is defined in custom.scss to center the text in the cell.
-            {%- endcomment -%}
-            {%- if first_day and forloop.first -%}
-              {%- assign week_extra_element = site.data.week_extra.week_extra[week_extra_index] -%}
-              <td class="{{ is_even }} week-cell" rowspan="{{ week.size | times: site.data.syllabus.default_day_rowspan }}" id="week-{{ week.name }}">
-                {{ week_number }}
-                {%- if week_extra_element.show_extra -%}
-                  {%- if week_extra_element.link and week_extra_element.link != empty -%}
-                    <br>
-                    <a
-                      href="{{ week_extra_element.link | relative_url }}"
-                      aria-label="{{ week_extra_element.name }} for Week {{ week_number }}"
-                    >
-                      {{- week_extra_element.name -}}
-                    </a>
-                  {%- elsif week_extra_element.name and week_extra_element.name != empty -%}
-                    <br>
-                    {{ week_extra_element.name }}
+          {% comment %}
+            - Hang on to the first day of the week, so we can render the week number
+            only once per week.
+          {% endcomment %}
+          {%- assign first_weekday = forloop.first -%}
+          {%- for i in (1..day_rowspan) -%}
+            {% comment %}
+              - If we are rendering the week number, we want this row to have the
+              "starting-row" class, which is used in custom.scss to
+              re-add the border to the left side of the table. Otherwise, we just
+              want it to open a table row.
+            {% endcomment %}
+            {% if first_weekday and forloop.first %}
+              {%- assign row_class = 'starting-row' -%}
+            {% else %}
+              {%- assign row_class = '' -%}
+            {% endif %}
+            <tr class="{{ row_class }}">
+              {%- comment -%}
+                - Open the table row and render the week number column.
+                - We use forloop.first to render the week number only once per week.
+                - We use the "size" field of the week hash to see how many days we're
+                going to display in the week, which tells us how many rows the week
+                number needs to span.
+                - We use the "name" field of the week hash to give us a unique week
+                number (between 1 and 52), which gives each week number box a unique
+                id, and thus allows us to implement the "jump to current week"
+                functionality.
+                - Additional text (e.g. link to weekly survey) can be placed underneath
+                  the week number by using week_extra.yml.
+                - week-cell is defined in custom.scss to center the text in the cell.
+              {%- endcomment -%}
+              {%- if first_weekday and forloop.first -%}
+                {%- assign week_extra_element = site.data.week_extra.week_extra[week_extra_index] -%}
+                <td
+                  class="{{ is_even }} week-cell"
+                  rowspan="{{ week.size | times: day_rowspan }}"
+                  id="week-{{ week.name }}"
+                >
+                  {{ week_number }}
+                  {%- if week_extra_element.show_extra -%}
+                    {%- if week_extra_element.link and week_extra_element.link != empty -%}
+                      <br>
+                      <a
+                        href="{{ week_extra_element.link | relative_url }}"
+                        aria-label="{{ week_extra_element.name }} for Week {{ week_number }}"
+                      >
+                        {{- week_extra_element.name -}}
+                      </a>
+                    {%- elsif week_extra_element.name and week_extra_element.name != empty -%}
+                      <br>
+                      {{ week_extra_element.name }}
+                    {%- endif -%}
                   {%- endif -%}
-                {%- endif -%}
-              </td>
-              {%- assign week_extra_index = week_extra_index | plus: 1 -%}
-            {%- endif -%}
-
-            {%- comment -%}
-              - Render the date column.
-              - The percent formatters determine how the date is displayed.
-              See this link for what percent formatters are available:
-              https://shopify.github.io/liquid/filters/date/
-              - The border-hack exists because Just the Docs is very dumb
-              and insists on clearing borders when td:first-of-type. This affects
-              the date column only, and hopefully this hack doesn't require any
-              touching to keep working (it just re-adds the border back).
-              - 
-            {%- endcomment -%}
-            {%- if forloop.first -%}
-              <td class="{{ is_even }} border-hack" rowspan="{{ site.data.syllabus.default_day_rowspan }}">{{ day | date: '%a<br>%b %d' }}</td>
-            {%- endif -%}
-
-            {%- comment -%}
-              - There are four chunks of code below this, for rendering the
-              lecture/readings/discussion/homework/project columns. For
-              simplicity, the chunks of code are identical (only swapping
-              out the column names); I highly recommend not changing one
-              of them individually. If you want to customize a column, you
-              should be doing that in lecture.html, discussion.html,
-              homework.html, or project.html.
-              - In each chunk, we check if the rowspan counter has hit 0.
-              If so, then it's time to render a new box.
-              - Using the index counter, we access the next element in the
-              yml file for rendering.
-              - If the element in the yml file has a custom rowspan, we note that.
-              Otherwise, we use the default rowspan.
-              - Now we render a new box by using one of the _includes. We pass in:
-              - element: The data from the yml file
-              - number: The number counter from this code
-              - rowspan: The rowspan (custom or default) from this code
-              - is_even: The alternating color setting from this code
-              - We reset the rowspan counter to start counting down from the new
-              rowspan, so that when we hit 0, we'll render the next box.
-              - We increment the index counter so that we can render the next
-              element in the yml array next time.
-              - If the "nonumber" field is True in the yml for this element, then
-              we don't increment the number counter. (e.g. if we have a box with
-              "no lecture", we don't need to increment the lecture number).
-              - If the rowspan counter did not hit 0, we just decrement the rowspan
-              counter and keep looping through days/weeks until it's time to render
-              a new box.
-            {%- endcomment -%}
-
-            {%- comment -%}
-              - Render the lecture column.
-              - For simplicity, the code for each column should be kept identical (only
-              swapping out the column names.
-            {%- endcomment -%}
-            {%- if lecture_rowspan == 0 -%}
-              {%- assign lecture_element = site.data.lectures.lectures[lecture_index] -%}
-              {%- if lecture_element.rowspan -%}
-                {%- assign new_rowspan = lecture_element.rowspan -%}
-              {%- else -%}
-                {%- assign new_rowspan = default_lecture_rowspan -%}
+                </td>
+                {%- assign week_extra_index = week_extra_index | plus: 1 -%}
               {%- endif -%}
-              {%- include lecture.html element=lecture_element number=lecture_number rowspan=new_rowspan is_even=is_even -%}
-              {%- assign lecture_rowspan = new_rowspan | plus: -1 -%}
-              {%- assign lecture_index = lecture_index | plus: 1 -%}
-              {%- unless lecture_element.nonumber -%}
-                {%- assign lecture_number = lecture_number | plus: 1 -%}
-              {%- endunless -%}
-            {%- else -%}
-              {%- assign lecture_rowspan = lecture_rowspan | plus: -1 -%}
-            {%- endif -%}
 
-            {%- comment -%}
-              - Render the readings column.
-              - For simplicity, the code for each column should be kept identical (only
+              {%- comment -%}
+                - Render the date column.
+                - The percent formatters determine how the date is displayed.
+                See this link for what percent formatters are available:
+                https://shopify.github.io/liquid/filters/date/
+              {%- endcomment -%}
+              {%- if forloop.first -%}
+                <td class="{{ is_even }}" rowspan="{{ day_rowspan }}">
+                  {{ day | date: '%a<br>%b %d' }}
+                </td>
+              {%- endif -%}
+
+              {%- comment -%}
+                - There are four chunks of code below this, for rendering the
+                lecture/readings/discussion/homework/project columns. For
+                simplicity, the chunks of code are identical (only swapping
+                out the column names); I highly recommend not changing one
+                of them individually. If you want to customize a column, you
+                should be doing that in lecture.html, discussion.html,
+                homework.html, or project.html.
+                - In each chunk, we check if the rowspan counter has hit 0.
+                If so, then it's time to render a new box.
+                - Using the index counter, we access the next element in the
+                yml file for rendering.
+                - If the element in the yml file has a custom rowspan, we note that.
+                Otherwise, we use the default rowspan.
+                - Now we render a new box by using one of the _includes. We pass in:
+                - element: The data from the yml file
+                - number: The number counter from this code
+                - rowspan: The rowspan (custom or default) from this code
+                - is_even: The alternating color setting from this code
+                - We reset the rowspan counter to start counting down from the new
+                rowspan, so that when we hit 0, we'll render the next box.
+                - We increment the index counter so that we can render the next
+                element in the yml array next time.
+                - If the "nonumber" field is True in the yml for this element, then
+                we don't increment the number counter. (e.g. if we have a box with
+                "no lecture", we don't need to increment the lecture number).
+                - If the rowspan counter did not hit 0, we just decrement the rowspan
+                counter and keep looping through days/weeks until it's time to render
+                a new box.
+              {%- endcomment -%}
+
+              {%- comment -%}
+                - Render the lecture column.
+                - For simplicity, the code for each column should be kept identical (only
                 swapping out the column names.
-              - Slightly breaking my own rule here by using lectures.yml, as keeping
-                readings/lectures together feels more natural. TODO: might clean this later.
-              - This is commented out because the template defaults to putting readings in
-                the lectures box. If you would like a separate readings column, uncomment.
-            {%- endcomment -%}
-            {%- comment -%}
-              {%- if readings_rowspan == 0 -%}
-                {%- assign readings_element = site.data.lectures.lectures[readings_index] -%}
-                {%- if readings_element.rowspan -%}
-                  {%- assign new_rowspan = readings_element.rowspan -%}
+              {%- endcomment -%}
+              {%- if lecture_rowspan == 0 -%}
+                {%- assign lecture_element = site.data.lectures.lectures[lecture_index] -%}
+                {%- if lecture_element.rowspan -%}
+                  {%- assign new_rowspan = lecture_element.rowspan -%}
                 {%- else -%}
-                  {%- assign new_rowspan = default_readings_rowspan -%}
+                  {%- assign new_rowspan = default_lecture_rowspan -%}
                 {%- endif -%}
-                {%- include readings.html element=readings_element number=readings_number rowspan=new_rowspan is_even=is_even  -%}
-                {%- assign readings_rowspan = new_rowspan | plus:-1 -%}
-                {%- assign readings_index = readings_index | plus:1 -%}
-                {%- unless readings_element.nonumber -%}
-                  {%- assign readings_number = readings_number | plus:1 -%}
+                {%- include lecture.html element=lecture_element number=lecture_number rowspan=new_rowspan is_even=is_even -%}
+                {%- assign lecture_rowspan = new_rowspan | plus: -1 -%}
+                {%- assign lecture_index = lecture_index | plus: 1 -%}
+                {%- unless lecture_element.nonumber -%}
+                  {%- assign lecture_number = lecture_number | plus: 1 -%}
                 {%- endunless -%}
               {%- else -%}
-                {%- assign readings_rowspan = readings_rowspan | plus:-1 -%}
+                {%- assign lecture_rowspan = lecture_rowspan | plus: -1 -%}
               {%- endif -%}
-            {%- endcomment -%}
 
-            {%- comment -%}
-              - Render the discussion column.
-              - For simplicity, the code for each column should be kept identical (only
-              swapping out the column names.
-            {%- endcomment -%}
-            {%- if discussion_rowspan == 0 -%}
-              {%- assign discussion_element = site.data.discussions.discussions[discussion_index] -%}
-              {%- if discussion_element.rowspan -%}
-                {%- assign new_rowspan = discussion_element.rowspan -%}
-              {%- else -%}
-                {%- assign new_rowspan = default_discussion_rowspan -%}
-              {%- endif -%}
-              {%- include discussion.html element=discussion_element number=discussion_number rowspan=new_rowspan is_even=is_even -%}
-              {%- assign discussion_rowspan = new_rowspan | plus: -1 -%}
-              {%- assign discussion_index = discussion_index | plus: 1 -%}
-              {%- unless discussion_element.nonumber -%}
-                {%- assign discussion_number = discussion_number | plus: 1 -%}
-              {%- endunless -%}
-            {%- else -%}
-              {%- assign discussion_rowspan = discussion_rowspan | plus: -1 -%}
-            {%- endif -%}
+              {%- comment -%}
+                - Render the readings column.
+                - For simplicity, the code for each column should be kept identical (only
+                  swapping out the column names.
+                - Slightly breaking my own rule here by using lectures.yml, as keeping
+                  readings/lectures together feels more natural. TODO: might clean this later.
+                - This is commented out because the template defaults to putting readings in
+                  the lectures box. If you would like a separate readings column, uncomment.
+              {%- endcomment -%}
+              {%- comment -%}
+                {%- if readings_rowspan == 0 -%}
+                  {%- assign readings_element = site.data.lectures.lectures[readings_index] -%}
+                  {%- if readings_element.rowspan -%}
+                    {%- assign new_rowspan = readings_element.rowspan -%}
+                  {%- else -%}
+                    {%- assign new_rowspan = default_readings_rowspan -%}
+                  {%- endif -%}
+                  {%- include readings.html element=readings_element number=readings_number rowspan=new_rowspan is_even=is_even  -%}
+                  {%- assign readings_rowspan = new_rowspan | plus:-1 -%}
+                  {%- assign readings_index = readings_index | plus:1 -%}
+                  {%- unless readings_element.nonumber -%}
+                    {%- assign readings_number = readings_number | plus:1 -%}
+                  {%- endunless -%}
+                {%- else -%}
+                  {%- assign readings_rowspan = readings_rowspan | plus:-1 -%}
+                {%- endif -%}
+              {%- endcomment -%}
 
-            {%- comment -%}
-              - Render the lab column.
-              - For simplicity, the code for each column should be kept identical (only
-              swapping out the column names.
-              - This is commented out because the template defaults to not using labs.
-              If your class has labs, uncomment.
-            {%- endcomment -%}
-            {%- comment -%}
-              {%- if lab_rowspan == 0 -%}
-              {%- assign lab_element = site.data.labs.labs[lab_index] -%}
-              {%- if lab_element.rowspan -%}
-              {%- assign new_rowspan = lab_element.rowspan -%}
+              {%- comment -%}
+                - Render the discussion column.
+                - For simplicity, the code for each column should be kept identical (only
+                swapping out the column names.
+              {%- endcomment -%}
+              {%- if discussion_rowspan == 0 -%}
+                {%- assign discussion_element = site.data.discussions.discussions[discussion_index] -%}
+                {%- if discussion_element.rowspan -%}
+                  {%- assign new_rowspan = discussion_element.rowspan -%}
+                {%- else -%}
+                  {%- assign new_rowspan = default_discussion_rowspan -%}
+                {%- endif -%}
+                {%- include discussion.html element=discussion_element number=discussion_number rowspan=new_rowspan is_even=is_even -%}
+                {%- assign discussion_rowspan = new_rowspan | plus: -1 -%}
+                {%- assign discussion_index = discussion_index | plus: 1 -%}
+                {%- unless discussion_element.nonumber -%}
+                  {%- assign discussion_number = discussion_number | plus: 1 -%}
+                {%- endunless -%}
               {%- else -%}
-              {%- assign new_rowspan = default_lab_rowspan -%}
+                {%- assign discussion_rowspan = discussion_rowspan | plus: -1 -%}
               {%- endif -%}
-              {%- include lab.html element=lab_element number=lab_number rowspan=new_rowspan is_even=is_even  -%}
-              {%- assign lab_rowspan = new_rowspan | plus:-1 -%}
-              {%- assign lab_index = lab_index | plus:1 -%}
-              {%- unless lab_element.nonumber -%}
-              {%- assign lab_number = lab_number | plus:1 -%}
-              {%- endunless -%}
-              {%- else -%}
-              {%- assign lab_rowspan = lab_rowspan | plus:-1 -%}
-              {%- endif -%}
-            {%- endcomment -%}
 
-            {%- comment -%}
-              - Render the homework column.
-              - For simplicity, the code for each column should be kept identical (only
-              swapping out the column names.
-            {%- endcomment -%}
-            {%- if homework_rowspan == 0 -%}
-              {%- assign homework_element = site.data.homeworks.homeworks[homework_index] -%}
-              {%- if homework_element.rowspan -%}
-                {%- assign new_rowspan = homework_element.rowspan -%}
-              {%- else -%}
-                {%- assign new_rowspan = default_homework_rowspan -%}
-              {%- endif -%}
-              {%- include homework.html element=homework_element number=homework_number rowspan=new_rowspan is_even=is_even -%}
-              {%- assign homework_rowspan = new_rowspan | plus: -1 -%}
-              {%- assign homework_index = homework_index | plus: 1 -%}
-              {%- unless homework_element.nonumber -%}
-                {%- assign homework_number = homework_number | plus: 1 -%}
-              {%- endunless -%}
-            {%- else -%}
-              {%- assign homework_rowspan = homework_rowspan | plus: -1 -%}
-            {%- endif -%}
+              {%- comment -%}
+                - Render the lab column.
+                - For simplicity, the code for each column should be kept identical (only
+                swapping out the column names.
+                - This is commented out because the template defaults to not using labs.
+                If your class has labs, uncomment.
+              {%- endcomment -%}
+              {%- comment -%}
+                {%- if lab_rowspan == 0 -%}
+                {%- assign lab_element = site.data.labs.labs[lab_index] -%}
+                {%- if lab_element.rowspan -%}
+                {%- assign new_rowspan = lab_element.rowspan -%}
+                {%- else -%}
+                {%- assign new_rowspan = default_lab_rowspan -%}
+                {%- endif -%}
+                {%- include lab.html element=lab_element number=lab_number rowspan=new_rowspan is_even=is_even  -%}
+                {%- assign lab_rowspan = new_rowspan | plus:-1 -%}
+                {%- assign lab_index = lab_index | plus:1 -%}
+                {%- unless lab_element.nonumber -%}
+                {%- assign lab_number = lab_number | plus:1 -%}
+                {%- endunless -%}
+                {%- else -%}
+                {%- assign lab_rowspan = lab_rowspan | plus:-1 -%}
+                {%- endif -%}
+              {%- endcomment -%}
 
-            {%- comment -%}
-              - Render the project column.
-              - For simplicity, the code for each column should be kept identical (only
-              swapping out the column names.
-            {%- endcomment -%}
-            {%- if project_rowspan == 0 -%}
-              {%- assign project_element = site.data.projects.projects[project_index] -%}
-              {%- if project_element.rowspan -%}
-                {%- assign new_rowspan = project_element.rowspan -%}
+              {%- comment -%}
+                - Render the homework column.
+                - For simplicity, the code for each column should be kept identical (only
+                swapping out the column names.
+              {%- endcomment -%}
+              {%- if homework_rowspan == 0 -%}
+                {%- assign homework_element = site.data.homeworks.homeworks[homework_index] -%}
+                {%- if homework_element.rowspan -%}
+                  {%- assign new_rowspan = homework_element.rowspan -%}
+                {%- else -%}
+                  {%- assign new_rowspan = default_homework_rowspan -%}
+                {%- endif -%}
+                {%- include homework.html element=homework_element number=homework_number rowspan=new_rowspan is_even=is_even -%}
+                {%- assign homework_rowspan = new_rowspan | plus: -1 -%}
+                {%- assign homework_index = homework_index | plus: 1 -%}
+                {%- unless homework_element.nonumber -%}
+                  {%- assign homework_number = homework_number | plus: 1 -%}
+                {%- endunless -%}
               {%- else -%}
-                {%- assign new_rowspan = default_project_rowspan -%}
+                {%- assign homework_rowspan = homework_rowspan | plus: -1 -%}
               {%- endif -%}
-              {%- include project.html element=project_element number=project_number rowspan=new_rowspan is_even=is_even -%}
-              {%- assign project_rowspan = new_rowspan | plus: -1 -%}
-              {%- assign project_index = project_index | plus: 1 -%}
-              {%- unless project_element.nonumber -%}
-                {%- assign project_number = project_number | plus: 1 -%}
-              {%- endunless -%}
-            {%- else -%}
-              {%- assign project_rowspan = project_rowspan | plus: -1 -%}
-            {%- endif -%}
-          </tr>
+
+              {%- comment -%}
+                - Render the project column.
+                - For simplicity, the code for each column should be kept identical (only
+                swapping out the column names.
+              {%- endcomment -%}
+              {%- if project_rowspan == 0 -%}
+                {%- assign project_element = site.data.projects.projects[project_index] -%}
+                {%- if project_element.rowspan -%}
+                  {%- assign new_rowspan = project_element.rowspan -%}
+                {%- else -%}
+                  {%- assign new_rowspan = default_project_rowspan -%}
+                {%- endif -%}
+                {%- include project.html element=project_element number=project_number rowspan=new_rowspan is_even=is_even -%}
+                {%- assign project_rowspan = new_rowspan | plus: -1 -%}
+                {%- assign project_index = project_index | plus: 1 -%}
+                {%- unless project_element.nonumber -%}
+                  {%- assign project_number = project_number | plus: 1 -%}
+                {%- endunless -%}
+              {%- else -%}
+                {%- assign project_rowspan = project_rowspan | plus: -1 -%}
+              {%- endif -%}
+            </tr>
           {%- endfor -%}
         {%- endfor -%}
       {%- endfor -%}

--- a/_includes/syllabus.html
+++ b/_includes/syllabus.html
@@ -167,6 +167,9 @@
           - In a given week, iterate through all the days in that week.
         {%- endcomment -%}
         {%- for day in week.items -%}
+          {%- assign first_day = forloop.first -%}
+          {%- assign start = 1 -%}
+          {%- for i in (start...site.data.syllabus.default_day_rowspan) -%}
           <tr>
             {%- comment -%}
               - Render the week number column.
@@ -182,9 +185,9 @@
                 the week number by using week_extra.yml.
               - week-cell is defined in custom.scss to center the text in the cell.
             {%- endcomment -%}
-            {%- if forloop.first -%}
+            {%- if first_day and forloop.first -%}
               {%- assign week_extra_element = site.data.week_extra.week_extra[week_extra_index] -%}
-              <td class="{{ is_even }} week-cell" rowspan="{{ week.size }}" id="week-{{ week.name }}">
+              <td class="{{ is_even }} week-cell" rowspan="{{ week.size | times: site.data.syllabus.default_day_rowspan }}" id="week-{{ week.name }}">
                 {{ week_number }}
                 {%- if week_extra_element.show_extra -%}
                   {%- if week_extra_element.link and week_extra_element.link != empty -%}
@@ -213,8 +216,11 @@
               and insists on clearing borders when td:first-of-type. This affects
               the date column only, and hopefully this hack doesn't require any
               touching to keep working (it just re-adds the border back).
+              - 
             {%- endcomment -%}
-            <td class="{{ is_even }} border-hack">{{ day | date: '%a<br>%b %d' }}</td>
+            {%- if forloop.first -%}
+              <td class="{{ is_even }} border-hack" rowspan="{{ site.data.syllabus.default_day_rowspan }}">{{ day | date: '%a<br>%b %d' }}</td>
+            {%- endif -%}
 
             {%- comment -%}
               - There are four chunks of code below this, for rendering the
@@ -389,6 +395,7 @@
               {%- assign project_rowspan = project_rowspan | plus: -1 -%}
             {%- endif -%}
           </tr>
+          {%- endfor -%}
         {%- endfor -%}
       {%- endfor -%}
     </tbody>

--- a/_includes/syllabus.html
+++ b/_includes/syllabus.html
@@ -169,30 +169,37 @@
           - In a given week, iterate through all the days in that week.
         {%- endcomment -%}
         {%- for day in week.items -%}
-          {% comment %}
+          {%- comment -%}
             - Hang on to the first day of the week, so we can render the week number
-            only once per week.
-          {% endcomment %}
+              only once per week.
+          {%- endcomment -%}
           {%- assign first_weekday = forloop.first -%}
+          {%- comment -%}
+            - This for loop allows us to render multiple rows for a single day.
+            - It is only relevant if day_rowspan is not the default (1).
+              Otherwise, the loop runs once and we render one row per day.
+          {%- endcomment -%}
           {%- for i in (1..day_rowspan) -%}
-            {% comment %}
+            {%- comment -%}
               - If we are rendering the week number, we want this row to have the
-              "starting-row" class, which is used in custom.scss to
-              re-add the border to the left side of the table. Otherwise, we just
-              want it to open a table row.
-            {% endcomment %}
-            {% if first_weekday and forloop.first %}
+                "starting-row" class, which is used in custom.scss to re-add
+                the border to the left side of the table. Otherwise, we just
+                want it to open a table row.
+            {%- endcomment -%}
+            {%- if first_weekday and forloop.first -%}
               {%- assign row_class = 'starting-row' -%}
-            {% else %}
+            {%- else -%}
               {%- assign row_class = '' -%}
-            {% endif %}
+            {%- endif -%}
             <tr class="{{ row_class }}">
               {%- comment -%}
                 - Open the table row and render the week number column.
-                - We use forloop.first to render the week number only once per week.
+                - We use forloop.first and first_weekday to render the week number
+                  only once per week.
                 - We use the "size" field of the week hash to see how many days we're
-                going to display in the week, which tells us how many rows the week
-                number needs to span.
+                  going to display in the week, which tells us how many rows the week
+                  number needs to span. We multiply by day_rowspan because that's the
+                  number of rows rendered per day.
                 - We use the "name" field of the week hash to give us a unique week
                 number (between 1 and 52), which gives each week number box a unique
                 id, and thus allows us to implement the "jump to current week"
@@ -229,6 +236,9 @@
 
               {%- comment -%}
                 - Render the date column.
+                - The if-condition ensures we only render the date column once per day.
+                  forloop.first is referencing the "1 to day_rowspan" loop, which renders
+                  potentially multiple columns per day.
                 - The percent formatters determine how the date is displayed.
                 See this link for what percent formatters are available:
                 https://shopify.github.io/liquid/filters/date/

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -24,8 +24,10 @@ table td.week-cell {
 // To use, add the class "spanned-table" to the table tag
 // and add the class "starting-row" to any row that 
 // touches the left side of the table.
-table.spanned-table tr:not(.starting-row) th,td {
-  border-left: $border $border-color!important;
+table.spanned-table tr:not(.starting-row) {
+  & th,td {
+    border-left: $border $border-color!important;
+  }
 }
 
 // Button copying

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -12,16 +12,20 @@ th {
   min-width: 0;
 }
 
-table {
-  td.border-hack {
-    border-left:1px solid $border-color;
-  }
+// Center "week" column, used in syllabus.html only
+table td.week-cell {
+  text-align: center; 
+  vertical-align: middle;
+}
 
-  // Center "week" column, used in syllabus.html only
-  td.week-cell {
-    text-align: center; 
-    vertical-align: middle;
-  }
+// Add a new table that overrides the default table styles
+// This is used in the syllabus.html file to allow for 
+// spanned cells that span multiple rows.
+// To use, add the class "spanned-table" to the table tag
+// and add the class "starting-row" to any row that 
+// touches the left side of the table.
+table.spanned-table tr:not(.starting-row) th,td {
+  border-left: $border $border-color!important;
 }
 
 // Button copying


### PR DESCRIPTION
Some courses require more than one box per day for a specific field in the table. This PR adds support for emitting multiple rows per day, so that content can stack correctly. It also rewrites `border-hack` to work with this new table implementation.